### PR TITLE
Add resend verification flow and block unverified logins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ PORT=8080
 SESSION_SECRET=super-secret-change-me
 STRIPE_SECRET_KEY=sk_test_xxxxxx
 STRIPE_WEBHOOK_SECRET=whsec_xxxxxx
+APP_URL=http://localhost:8080
+LOCAL_AI_URL=http://localhost:5001/generate
+PARSER_URL=http://localhost:5000/parse

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DATABASE_URL=postgres://user:pass@localhost:5432/creditninja?sslmode=disable
+OPENAI_API_KEY=sk-xxxxx
+LOCAL_AI_URL=http://localhost:11434/api/generate
+PARSER_URL=http://localhost:5000/parse
+APP_URL=http://localhost:8080
+STRIPE_SECRET_KEY=
+PORT=8080

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,5 @@
-DATABASE_URL=postgres://user:pass@localhost:5432/creditninja?sslmode=disable
-OPENAI_API_KEY=sk-xxxxx
-LOCAL_AI_URL=http://localhost:11434/api/generate
-PARSER_URL=http://localhost:5000/parse
-APP_URL=http://localhost:8080
-STRIPE_SECRET_KEY=
+DATABASE_URL=postgres://credit:creditpw@localhost:5432/creditninja?sslmode=disable
 PORT=8080
+SESSION_SECRET=super-secret-change-me
+STRIPE_SECRET_KEY=sk_test_xxxxxx
+STRIPE_WEBHOOK_SECRET=whsec_xxxxxx

--- a/Dockerfile.postgres
+++ b/Dockerfile.postgres
@@ -1,0 +1,5 @@
+FROM postgres:16
+ENV POSTGRES_USER=credit
+ENV POSTGRES_PASSWORD=creditpw
+ENV POSTGRES_DB=creditninja
+EXPOSE 5432

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# creditninja# CreditNinja
+# CreditNinja
 
 Lean & mean Golang credit‑repair automation platform.
 
@@ -16,7 +16,7 @@ go run ./cmd
 ```
 
 The app can integrate with a local AI service for PDF parsing and dispute letter generation.
-Set `LOCAL_AI_URL` and `PARSER_URL` in your `.env` to the endpoints of your microservices.
+Set `LOCAL_AI_URL`, `PARSER_URL`, and `APP_URL` in your `.env` to the endpoints of your microservices and the public app URL used in verification emails.
 
 ## Stack
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Lean & mean Golang credit‑repair automation platform.
 git clone <repo-url>
 cd creditninja
 cp .env.example .env   # edit secrets
+# start postgres (builds an image from Dockerfile.postgres)
+docker build -f Dockerfile.postgres -t creditninja-db .
+docker run --name creditdb -p 5432:5432 -d creditninja-db
 go mod tidy
 go run ./cmd
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ go mod tidy
 go run ./cmd
 ```
 
+The app can integrate with a local AI service for PDF parsing and dispute letter generation.
+Set `LOCAL_AI_URL` and `PARSER_URL` in your `.env` to the endpoints of your microservices.
+
 ## Stack
 
 * **Fiber** – blazing fast web framework

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("DB connection failed: %v", err)
 	}
+	if err := models.Migrate(db); err != nil {
+		log.Fatalf("DB migration failed: %v", err)
+	}
 	defer db.Close()
 
 	// Fiber with Go html/template engine

--- a/internal/handlers/billing.go
+++ b/internal/handlers/billing.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/session"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+
+	"creditninja/internal/models"
+)
+
+func billing(c *fiber.Ctx) error {
+	store := c.Locals("store").(*session.Store)
+	sess, _ := store.Get(c)
+	uidRaw := sess.Get("user_id")
+	if uidRaw == nil {
+		return c.Redirect("/login")
+	}
+	userID, _ := uuid.Parse(uidRaw.(string))
+
+	db := c.Locals("db").(*sqlx.DB)
+	user, err := models.GetUserByID(db, userID)
+	if err != nil {
+		return c.Redirect("/login")
+	}
+
+	return c.Render("billing", fiber.Map{"User": user})
+}

--- a/internal/handlers/dashboard.go
+++ b/internal/handlers/dashboard.go
@@ -22,7 +22,11 @@ func dashboard(c *fiber.Ctx) error {
 	var reports []models.CreditReport
 	db.Select(&reports, "SELECT * FROM credit_reports WHERE user_id=$1 ORDER BY created_at DESC", userID)
 
+	var letters []models.DisputeLetter
+	db.Select(&letters, "SELECT * FROM dispute_letters WHERE user_id=$1 ORDER BY created_at DESC", userID)
+
 	return c.Render("dashboard", fiber.Map{
 		"Reports": reports,
+		"Letters": letters,
 	})
 }

--- a/internal/handlers/letters.go
+++ b/internal/handlers/letters.go
@@ -1,0 +1,79 @@
+package handlers
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/session"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+
+	"creditninja/internal/models"
+	"creditninja/internal/services"
+)
+
+func createLetter(c *fiber.Ctx) error {
+	store := c.Locals("store").(*session.Store)
+	sess, _ := store.Get(c)
+	uidRaw := sess.Get("user_id")
+	if uidRaw == nil {
+		return c.Redirect("/login")
+	}
+	userID, _ := uuid.Parse(uidRaw.(string))
+
+	db := c.Locals("db").(*sqlx.DB)
+	user, err := models.GetUserByID(db, userID)
+	if err != nil {
+		return c.Redirect("/login")
+	}
+	if !user.Verified {
+		return c.Redirect("/check-email?email=" + user.Email)
+	}
+	if !user.Paid {
+		return c.Status(fiber.StatusPaymentRequired).SendString("Upgrade required")
+	}
+
+	reportIDStr := c.FormValue("report_id")
+	if reportIDStr == "" {
+		return c.Status(400).SendString("report_id required")
+	}
+	reportID, err := uuid.Parse(reportIDStr)
+	if err != nil {
+		return c.Status(400).SendString("bad report_id")
+	}
+
+	var report models.CreditReport
+	if err := db.Get(&report, "SELECT * FROM credit_reports WHERE id=$1 AND user_id=$2", reportID, userID); err != nil {
+		return c.Status(404).SendString("report not found")
+	}
+
+	prompt := "Generate a dispute letter based on this report: " + report.ParsedJSON
+	text, err := services.GenerateLetter(prompt)
+	if err != nil {
+		return c.Status(500).SendString("AI error")
+	}
+
+	outDir := "./static/letters"
+	os.MkdirAll(outDir, 0755)
+	pdfPath := filepath.Join(outDir, uuid.New().String()+".pdf")
+	if err := services.RenderPDF(text, pdfPath); err != nil {
+		return c.Status(500).SendString("PDF error")
+	}
+
+	letter := &models.DisputeLetter{
+		ID:        uuid.New(),
+		UserID:    userID,
+		ReportID:  reportID,
+		PdfPath:   pdfPath,
+		Round:     1,
+		Status:    "pending",
+		CreatedAt: time.Now(),
+	}
+	if err := models.CreateLetter(db, letter); err != nil {
+		return c.Status(500).SendString("DB error")
+	}
+
+	return c.Redirect("/dashboard")
+}

--- a/internal/handlers/router.go
+++ b/internal/handlers/router.go
@@ -22,8 +22,10 @@ func RegisterRoutes(app *fiber.App) {
 	app.Get("/verify/:token", VerifyEmail)
 
 	app.Get("/dashboard", dashboard)
+	app.Get("/billing", billing)
 
 	app.Post("/upload", upload)
+	app.Post("/letters", createLetter)
 
 	app.Get("/pay", pay)
 }

--- a/internal/handlers/router.go
+++ b/internal/handlers/router.go
@@ -14,7 +14,16 @@ func RegisterRoutes(app *fiber.App) {
 	app.Post("/login", auth.Login)
 	app.Get("/logout", auth.Logout)
 
+	app.Get("/check-email", func(c *fiber.Ctx) error {
+		return c.Render("check_email", fiber.Map{"Email": c.Query("email")})
+	})
+	app.Get("/verified", func(c *fiber.Ctx) error { return c.Render("verified", nil) })
+	app.Post("/resend-verification", ResendVerification)
+	app.Get("/verify/:token", VerifyEmail)
+
 	app.Get("/dashboard", dashboard)
+
+	app.Post("/upload", upload)
 
 	app.Get("/pay", pay)
 }

--- a/internal/handlers/upload.go
+++ b/internal/handlers/upload.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/session"
@@ -12,6 +11,7 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"creditninja/internal/models"
+	"creditninja/internal/services"
 )
 
 func upload(c *fiber.Ctx) error {
@@ -36,11 +36,11 @@ func upload(c *fiber.Ctx) error {
 		return c.Status(500).SendString("Upload failed")
 	}
 
-	// Parse stub
-	parsed, _ := json.Marshal(map[string]string{
-		"status":   "placeholder",
-		"uploaded": time.Now().String(),
-	})
+	parsedReport, err := services.ParseReport(rawPath)
+	if err != nil {
+		c.Context().Logger().Printf("parse error: %v", err)
+	}
+	parsed, _ := json.Marshal(parsedReport)
 
 	db := c.Locals("db").(*sqlx.DB)
 	_, err = models.CreateReport(db, userID, rawPath, string(parsed))

--- a/internal/handlers/verify.go
+++ b/internal/handlers/verify.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"os"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jmoiron/sqlx"
+
+	"creditninja/internal/models"
+	"creditninja/internal/services"
+)
+
+func VerifyEmail(c *fiber.Ctx) error {
+	token := c.Params("token")
+	db := c.Locals("db").(*sqlx.DB)
+
+	vt, err := models.GetVerificationToken(db, token)
+	if err != nil {
+		return c.Status(400).SendString("Invalid token")
+	}
+
+	_, err = db.Exec(`UPDATE users SET verified=true WHERE id=$1`, vt.UserID)
+	if err != nil {
+		return c.Status(500).SendString("DB error")
+	}
+
+	models.DeleteVerificationToken(db, token)
+	return c.Redirect("/verified")
+}
+
+// ResendVerification generates a new token and emails it to the user.
+func ResendVerification(c *fiber.Ctx) error {
+	email := c.FormValue("email")
+	if email == "" {
+		return c.Status(400).SendString("Email required")
+	}
+	db := c.Locals("db").(*sqlx.DB)
+	user, err := models.GetUserByEmail(db, email)
+	if err != nil {
+		return c.Status(400).SendString("User not found")
+	}
+	vt, err := models.CreateVerificationToken(db, user.ID)
+	if err == nil {
+		appURL := os.Getenv("APP_URL")
+		if appURL == "" {
+			appURL = "http://localhost:8080"
+		}
+		link := appURL + "/verify/" + vt.Token
+		services.SendEmail(user.Email, "Verify your email", link)
+	}
+	return c.Redirect("/check-email?email=" + user.Email)
+}

--- a/internal/models/migrate.go
+++ b/internal/models/migrate.go
@@ -11,9 +11,11 @@ func Migrate(db *sqlx.DB) error {
             password TEXT NOT NULL,
             role TEXT NOT NULL,
             verified BOOLEAN NOT NULL DEFAULT FALSE,
+            paid BOOLEAN NOT NULL DEFAULT FALSE,
             created_at TIMESTAMP NOT NULL
         );`,
 		`ALTER TABLE users ADD COLUMN IF NOT EXISTS verified BOOLEAN NOT NULL DEFAULT FALSE;`,
+		`ALTER TABLE users ADD COLUMN IF NOT EXISTS paid BOOLEAN NOT NULL DEFAULT FALSE;`,
 		`CREATE TABLE IF NOT EXISTS credit_reports (
             id UUID PRIMARY KEY,
             user_id UUID REFERENCES users(id) ON DELETE CASCADE,

--- a/internal/models/migrate.go
+++ b/internal/models/migrate.go
@@ -1,0 +1,45 @@
+package models
+
+import "github.com/jmoiron/sqlx"
+
+// Migrate runs the application schema migrations.
+func Migrate(db *sqlx.DB) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS users (
+            id UUID PRIMARY KEY,
+            email TEXT UNIQUE NOT NULL,
+            password TEXT NOT NULL,
+            role TEXT NOT NULL,
+            verified BOOLEAN NOT NULL DEFAULT FALSE,
+            created_at TIMESTAMP NOT NULL
+        );`,
+		`ALTER TABLE users ADD COLUMN IF NOT EXISTS verified BOOLEAN NOT NULL DEFAULT FALSE;`,
+		`CREATE TABLE IF NOT EXISTS credit_reports (
+            id UUID PRIMARY KEY,
+            user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+            raw_path TEXT NOT NULL,
+            parsed_json TEXT,
+            created_at TIMESTAMP NOT NULL
+        );`,
+		`CREATE TABLE IF NOT EXISTS dispute_letters (
+            id UUID PRIMARY KEY,
+            user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+            report_id UUID REFERENCES credit_reports(id) ON DELETE CASCADE,
+            pdf_path TEXT NOT NULL,
+            round INT NOT NULL,
+            status TEXT NOT NULL,
+            created_at TIMESTAMP NOT NULL
+        );`,
+		`CREATE TABLE IF NOT EXISTS verification_tokens (
+            token TEXT PRIMARY KEY,
+            user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+            expires_at TIMESTAMP NOT NULL
+        );`,
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -14,6 +14,7 @@ type User struct {
 	Password  string    `db:"password"`
 	Role      string    `db:"role"`
 	Verified  bool      `db:"verified"`
+	Paid      bool      `db:"paid"`
 	CreatedAt time.Time `db:"created_at"`
 }
 
@@ -36,18 +37,25 @@ func CreateUser(db *sqlx.DB, email, password, role string) (*User, error) {
 		Email:     email,
 		Role:      role,
 		Verified:  false,
+		Paid:      false,
 		CreatedAt: time.Now(),
 	}
 	if err := user.SetPassword(password); err != nil {
 		return nil, err
 	}
-	_, err := db.NamedExec(`INSERT INTO users (id, email, password, role, verified, created_at)
-                             VALUES (:id, :email, :password, :role, :verified, :created_at)`, user)
+	_, err := db.NamedExec(`INSERT INTO users (id, email, password, role, verified, paid, created_at)
+                             VALUES (:id, :email, :password, :role, :verified, :paid, :created_at)`, user)
 	return user, err
 }
 
 func GetUserByEmail(db *sqlx.DB, email string) (*User, error) {
 	var u User
 	err := db.Get(&u, "SELECT * FROM users WHERE email=$1", email)
+	return &u, err
+}
+
+func GetUserByID(db *sqlx.DB, id uuid.UUID) (*User, error) {
+	var u User
+	err := db.Get(&u, "SELECT * FROM users WHERE id=$1", id)
 	return &u, err
 }

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -13,6 +13,7 @@ type User struct {
 	Email     string    `db:"email"`
 	Password  string    `db:"password"`
 	Role      string    `db:"role"`
+	Verified  bool      `db:"verified"`
 	CreatedAt time.Time `db:"created_at"`
 }
 
@@ -34,13 +35,14 @@ func CreateUser(db *sqlx.DB, email, password, role string) (*User, error) {
 		ID:        uuid.New(),
 		Email:     email,
 		Role:      role,
+		Verified:  false,
 		CreatedAt: time.Now(),
 	}
 	if err := user.SetPassword(password); err != nil {
 		return nil, err
 	}
-	_, err := db.NamedExec(`INSERT INTO users (id, email, password, role, created_at)
-                             VALUES (:id, :email, :password, :role, :created_at)`, user)
+	_, err := db.NamedExec(`INSERT INTO users (id, email, password, role, verified, created_at)
+                             VALUES (:id, :email, :password, :role, :verified, :created_at)`, user)
 	return user, err
 }
 

--- a/internal/models/verification.go
+++ b/internal/models/verification.go
@@ -1,0 +1,36 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+)
+
+type VerificationToken struct {
+	Token     string    `db:"token"`
+	UserID    uuid.UUID `db:"user_id"`
+	ExpiresAt time.Time `db:"expires_at"`
+}
+
+func CreateVerificationToken(db *sqlx.DB, userID uuid.UUID) (*VerificationToken, error) {
+	vt := &VerificationToken{
+		Token:     uuid.New().String(),
+		UserID:    userID,
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	_, err := db.NamedExec(`INSERT INTO verification_tokens (token, user_id, expires_at)
+                            VALUES (:token, :user_id, :expires_at)`, vt)
+	return vt, err
+}
+
+func GetVerificationToken(db *sqlx.DB, token string) (*VerificationToken, error) {
+	var vt VerificationToken
+	err := db.Get(&vt, `SELECT * FROM verification_tokens WHERE token=$1`, token)
+	return &vt, err
+}
+
+func DeleteVerificationToken(db *sqlx.DB, token string) error {
+	_, err := db.Exec(`DELETE FROM verification_tokens WHERE token=$1`, token)
+	return err
+}

--- a/internal/services/ai.go
+++ b/internal/services/ai.go
@@ -1,16 +1,44 @@
 package services
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
 	"os"
+	"time"
 
 	openai "github.com/sashabaranov/go-openai"
 )
 
 func GenerateLetter(prompt string) (string, error) {
+	if url := os.Getenv("LOCAL_AI_URL"); url != "" {
+		payload, _ := json.Marshal(map[string]string{"prompt": prompt})
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(payload))
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		out, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+		return string(out), nil
+	}
+
 	client := openai.NewClient(os.Getenv("OPENAI_API_KEY"))
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	resp, err := client.CreateChatCompletion(
-		context.Background(),
+		ctx,
 		openai.ChatCompletionRequest{
 			Model: "gpt-4o-mini",
 			Messages: []openai.ChatCompletionMessage{

--- a/internal/services/parser.go
+++ b/internal/services/parser.go
@@ -1,0 +1,66 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"time"
+)
+
+type Tradeline struct {
+	Creditor string `json:"creditor"`
+	Account  string `json:"account"`
+	Status   string `json:"status"`
+}
+
+type ParsedReport struct {
+	Tradelines []Tradeline `json:"tradelines"`
+	Negatives  []Tradeline `json:"negatives"`
+}
+
+// ParseReport sends the PDF to a local parser microservice
+func ParseReport(path string) (ParsedReport, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return ParsedReport{}, err
+	}
+	defer file.Close()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", path)
+	if err != nil {
+		return ParsedReport{}, err
+	}
+	if _, err := io.Copy(part, file); err != nil {
+		return ParsedReport{}, err
+	}
+	writer.Close()
+
+	url := os.Getenv("PARSER_URL")
+	if url == "" {
+		url = "http://localhost:5000/parse"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "POST", url, &body)
+	if err != nil {
+		return ParsedReport{}, err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ParsedReport{}, err
+	}
+	defer resp.Body.Close()
+
+	var parsed ParsedReport
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return ParsedReport{}, err
+	}
+	return parsed, nil
+}

--- a/internal/services/pdf.go
+++ b/internal/services/pdf.go
@@ -1,12 +1,19 @@
 package services
 
-import "github.com/signintech/gopdf"
+import (
+	"github.com/signintech/gopdf"
+)
 
-func GenerateDisputePDF(filename, body string) error {
-    pdf := gopdf.GoPdf{}
-    pdf.Start(gopdf.Config{PageSize: *gopdf.PageSizeA4})
-    pdf.AddPage()
-    pdf.SetFont("Helvetica", "", 14)
-    pdf.Cell(nil, body)
-    return pdf.WritePdf(filename)
+func RenderPDF(text, path string) error {
+	pdf := gopdf.GoPdf{}
+	pdf.Start(gopdf.Config{PageSize: *gopdf.PageSizeA4})
+	pdf.AddPage()
+	if err := pdf.AddTTFFont("Arial", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"); err != nil {
+		return err
+	}
+	if err := pdf.SetFont("Arial", "", 14); err != nil {
+		return err
+	}
+	pdf.Cell(nil, text)
+	return pdf.WritePdf(path)
 }

--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -10,7 +10,10 @@
 <body class="bg-gray-100 min-h-screen">
   <nav class="bg-purple-700 text-white p-4">
     <a href="/" class="font-bold">CreditNinja</a>
-    {{if .User}}<a href="/logout" class="float-right underline">Logout</a>{{end}}
+    {{if .User}}
+    <a href="/billing" class="underline mx-4">Billing</a>
+    <a href="/logout" class="float-right underline">Logout</a>
+    {{end}}
   </nav>
 
   <main class="p-4 max-w-3xl mx-auto">

--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -17,7 +17,7 @@
   </nav>
 
   <main class="p-4 max-w-3xl mx-auto">
-    {{block "body" .}}{{end}}   <!-- this is the slot -->
+    {{block "content" .}}{{end}}   <!-- this is the slot -->
   </main>
 </body>
 </html>

--- a/internal/templates/billing.html
+++ b/internal/templates/billing.html
@@ -1,0 +1,10 @@
+{{define "billing"}}
+{{template "base" .}}
+{{block "content" .}}
+<h1 class="text-xl mb-4">Billing</h1>
+<p>Your current plan: {{if .User.Paid}}Paid{{else}}Free{{end}}</p>
+{{if not .User.Paid}}
+<a href="/pay" class="inline-block mt-4 bg-purple-600 text-white p-2 rounded">Upgrade</a>
+{{end}}
+{{end}}
+{{end}}

--- a/internal/templates/check_email.html
+++ b/internal/templates/check_email.html
@@ -1,0 +1,11 @@
+{{define "check_email"}}
+{{template "base" .}}
+{{block "content" .}}
+<h1 class="text-xl mb-4">Check your email</h1>
+<p>We've sent a verification link to {{.Email}}. Please click the link to verify your account.</p>
+<form action="/resend-verification" method="post" class="mt-4">
+  <input type="hidden" name="email" value="{{.Email}}">
+  <button class="bg-purple-600 text-white p-2 rounded">Resend verification email</button>
+</form>
+{{end}}
+{{end}}

--- a/internal/templates/dashboard.html
+++ b/internal/templates/dashboard.html
@@ -28,5 +28,25 @@
     {{end}}
   </tbody>
 </table>
+
+<h2 class="text-xl font-medium mt-8 mb-2">Your Letters</h2>
+<table class="border w-full bg-white shadow rounded">
+  <thead>
+    <tr class="bg-gray-200">
+      <th class="p-2 border">Round</th>
+      <th class="p-2 border">Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{range .Letters}}
+    <tr>
+      <td class="p-2 border">{{.Round}}</td>
+      <td class="p-2 border">{{.Status}}</td>
+    </tr>
+    {{else}}
+    <tr><td colspan="2" class="p-4 text-center">No letters yet</td></tr>
+    {{end}}
+  </tbody>
+</table>
 {{end}}
 {{end}}

--- a/internal/templates/dashboard.html
+++ b/internal/templates/dashboard.html
@@ -15,6 +15,7 @@
     <tr class="bg-gray-200">
       <th class="p-2 border">Uploaded</th>
       <th class="p-2 border">Status</th>
+      <th class="p-2 border"></th>
     </tr>
   </thead>
   <tbody>
@@ -22,6 +23,12 @@
     <tr>
       <td class="p-2 border">{{.CreatedAt.Format "02 Jan 2006 15:04"}}</td>
       <td class="p-2 border">Parsed</td>
+      <td class="p-2 border">
+        <form action="/letters" method="post">
+          <input type="hidden" name="report_id" value="{{.ID}}">
+          <button class="bg-purple-600 text-white px-2 py-1 rounded">Generate Letter</button>
+        </form>
+      </td>
     </tr>
     {{else}}
     <tr><td colspan="2" class="p-4 text-center">No reports yet</td></tr>

--- a/internal/templates/verified.html
+++ b/internal/templates/verified.html
@@ -1,0 +1,7 @@
+{{define "verified"}}
+{{template "base" .}}
+{{block "content" .}}
+<h1 class="text-xl mb-4">Email verified</h1>
+<p>Your email has been successfully verified. You can now <a href="/login" class="underline text-purple-700">login</a>.</p>
+{{end}}
+{{end}}


### PR DESCRIPTION
## Summary
- block unverified users from logging in
- allow resending of verification emails
- wire the resend route
- add button on the check_email page

## Testing
- `go vet ./...`
- `go mod tidy`


------
https://chatgpt.com/codex/tasks/task_e_684babd74404832e99d02119da6bd431