### PR TITLE
Add FastAPI prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,18 @@ go run ./cmd
 * **PostgreSQL** – primary datastore
 * **Stripe** – payments
 * **gopdf** – dispute‑letter PDF generation
+
+## Python FastAPI Version
+
+A minimal FastAPI implementation is located in `creditninja_py/`. Use it for experimentation with AI-powered dispute generation.
+
+### Quick Start
+
+```bash
+cd creditninja_py
+cp env.example .env
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+This version includes basic auth, PDF upload, AI dispute generation and Stripe webhook stubs. It is for educational use only and does not constitute legal advice.

--- a/creditninja_py/Dockerfile
+++ b/creditninja_py/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/creditninja_py/env.example
+++ b/creditninja_py/env.example
@@ -1,0 +1,5 @@
+DATABASE_URL=postgresql://user:password@db/creditninja
+SECRET_KEY=supersecret
+OPENAI_API_KEY=your-openai-key
+STRIPE_API_KEY=sk_test_yourkey
+STRIPE_WEBHOOK_SECRET=whsec_yoursecret

--- a/creditninja_py/main.py
+++ b/creditninja_py/main.py
@@ -1,0 +1,33 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from dotenv import load_dotenv
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import os
+
+load_dotenv()
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+app = FastAPI(title="CreditNinja")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+from routes import auth, upload, ai_disputes, stripe_webhooks
+
+app.include_router(auth.router)
+app.include_router(upload.router)
+app.include_router(ai_disputes.router)
+app.include_router(stripe_webhooks.router)
+
+@app.get("/")
+def read_root():
+    return {"message": "Welcome to CreditNinja"}

--- a/creditninja_py/models.py
+++ b/creditninja_py/models.py
@@ -1,0 +1,32 @@
+from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, Text
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
+
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = 'users'
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    is_active = Column(Boolean, default=True)
+    is_admin = Column(Boolean, default=False)
+    subscription_active = Column(Boolean, default=False)
+    reports = relationship('CreditReport', back_populates='owner')
+
+class CreditReport(Base):
+    __tablename__ = 'credit_reports'
+    id = Column(Integer, primary_key=True, index=True)
+    filename = Column(String)
+    owner_id = Column(Integer, ForeignKey('users.id'))
+    owner = relationship('User', back_populates='reports')
+    disputes = relationship('Dispute', back_populates='report')
+
+class Dispute(Base):
+    __tablename__ = 'disputes'
+    id = Column(Integer, primary_key=True, index=True)
+    item = Column(Text)
+    letter = Column(Text)
+    status = Column(String, default='pending')
+    report_id = Column(Integer, ForeignKey('credit_reports.id'))
+    report = relationship('CreditReport', back_populates='disputes')

--- a/creditninja_py/requirements.txt
+++ b/creditninja_py/requirements.txt
@@ -1,0 +1,13 @@
+fastapi
+uvicorn
+sqlalchemy
+psycopg2-binary
+python-multipart
+python-magic
+PyPDF2
+python-dotenv
+stripe
+itsdangerous
+passlib[bcrypt]
+python-jose
+jinja2

--- a/creditninja_py/routes/__init__.py
+++ b/creditninja_py/routes/__init__.py
@@ -1,0 +1,2 @@
+from . import auth, upload, ai_disputes, stripe_webhooks
+__all__ = ["auth", "upload", "ai_disputes", "stripe_webhooks"]

--- a/creditninja_py/routes/ai_disputes.py
+++ b/creditninja_py/routes/ai_disputes.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from ..models import CreditReport, Dispute
+from ..main import SessionLocal
+import os
+import openai
+
+router = APIRouter(prefix="/ai", tags=["ai"])
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@router.post('/generate/{report_id}')
+def generate_disputes(report_id: int, db: Session = Depends(get_db)):
+    report = db.query(CreditReport).filter(CreditReport.id == report_id).first()
+    if not report:
+        raise HTTPException(status_code=404, detail="Report not found")
+    # In reality we'd parse the PDF and feed to OpenAI
+    prompt = "Generate a dispute letter for negative items."
+    try:
+        resp = openai.Completion.create(model="text-davinci-003", prompt=prompt, max_tokens=150)
+        letter = resp.choices[0].text.strip()
+    except Exception:
+        letter = "Mock dispute letter content"
+    dispute = Dispute(item="Item description", letter=letter, report_id=report.id)
+    db.add(dispute)
+    db.commit()
+    db.refresh(dispute)
+    return {"dispute_id": dispute.id, "letter": dispute.letter}

--- a/creditninja_py/routes/auth.py
+++ b/creditninja_py/routes/auth.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, Depends, HTTPException, Form
+from sqlalchemy.orm import Session
+from passlib.context import CryptContext
+from jose import jwt
+from datetime import datetime, timedelta
+from ..models import User
+from ..main import SessionLocal
+import os
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+SECRET_KEY = os.getenv("SECRET_KEY", "secret")
+ALGORITHM = "HS256"
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@router.post('/signup')
+def signup(email: str = Form(...), password: str = Form(...), db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.email == email).first()
+    if user:
+        raise HTTPException(status_code=400, detail="Email already registered")
+    hashed_password = pwd_context.hash(password)
+    new_user = User(email=email, hashed_password=hashed_password)
+    db.add(new_user)
+    db.commit()
+    db.refresh(new_user)
+    return {"message": "User created"}
+
+@router.post('/login')
+def login(email: str = Form(...), password: str = Form(...), db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.email == email).first()
+    if not user or not pwd_context.verify(password, user.hashed_password):
+        raise HTTPException(status_code=400, detail="Invalid credentials")
+    data = {"sub": str(user.id), "exp": datetime.utcnow() + timedelta(hours=12)}
+    token = jwt.encode(data, SECRET_KEY, algorithm=ALGORITHM)
+    return {"access_token": token, "token_type": "bearer"}

--- a/creditninja_py/routes/stripe_webhooks.py
+++ b/creditninja_py/routes/stripe_webhooks.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, Request, HTTPException
+import stripe
+import os
+
+router = APIRouter(prefix="/stripe", tags=["stripe"])
+stripe.api_key = os.getenv("STRIPE_API_KEY")
+WEBHOOK_SECRET = os.getenv("STRIPE_WEBHOOK_SECRET")
+
+@router.post('/webhook')
+async def stripe_webhook(request: Request):
+    payload = await request.body()
+    sig_header = request.headers.get('stripe-signature')
+    try:
+        event = stripe.Webhook.construct_event(payload, sig_header, WEBHOOK_SECRET)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    # Handle the event
+    if event['type'] == 'invoice.paid':
+        # Activate subscription logic here
+        pass
+    return {'status': 'success'}

--- a/creditninja_py/routes/upload.py
+++ b/creditninja_py/routes/upload.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
+from sqlalchemy.orm import Session
+from ..models import CreditReport
+from ..main import SessionLocal
+import magic, os, shutil
+from PyPDF2 import PdfReader
+
+router = APIRouter(prefix="/upload", tags=["upload"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+UPLOAD_DIR = 'uploads'
+os.makedirs(UPLOAD_DIR, exist_ok=True)
+
+@router.post('/')
+def upload_report(file: UploadFile = File(...), db: Session = Depends(get_db)):
+    mime = magic.from_buffer(file.file.read(1024), mime=True)
+    file.file.seek(0)
+    if mime != 'application/pdf':
+        raise HTTPException(status_code=400, detail='Only PDF files allowed')
+    path = os.path.join(UPLOAD_DIR, file.filename)
+    with open(path, 'wb') as out:
+        shutil.copyfileobj(file.file, out)
+    reader = PdfReader(path)
+    text = "\n".join(page.extract_text() or '' for page in reader.pages)
+    report = CreditReport(filename=path)
+    db.add(report)
+    db.commit()
+    return {"message": "Uploaded", "text_snippet": text[:200]}

--- a/creditninja_py/templates/base.html
+++ b/creditninja_py/templates/base.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CreditNinja</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script src="https://unpkg.com/htmx.org@1.9.4" defer></script>
+</head>
+<body class="p-4">
+  <header class="mb-4">
+    <h1 class="text-2xl font-bold">CreditNinja</h1>
+  </header>
+  {% block content %}{% endblock %}
+  <footer class="mt-4 text-xs text-gray-600">
+    CreditNinja is an educational tool. Consult a professional for legal advice.
+  </footer>
+</body>
+</html>

--- a/creditninja_py/templates/dashboard.html
+++ b/creditninja_py/templates/dashboard.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<div>
+  <h2 class="text-xl mb-2">Dashboard</h2>
+  <p>Welcome to your dashboard.</p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- stub Python FastAPI backend in `creditninja_py`
- basic SQLAlchemy models and routes for auth, uploads, AI dispute generation and Stripe webhooks
- Tailwind/HTMX templates with compliance footer
- Dockerfile, requirements.txt and env example
- update README with Python instructions

## Testing
- `python -m compileall creditninja_py`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684cf128694c832eb18957947695fef1